### PR TITLE
Add support for new controller types

### DIFF
--- a/game.libretro.genplus-wide/addon.xml.in
+++ b/game.libretro.genplus-wide/addon.xml.in
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.genplus-wide"
 		name="Sega - MS/GG/MD/CD (Genesis Plus GX Wide)"
-		version="1.7.4.23"
+		version="1.7.4.24"
 		provider-name="Charles McDonald, Eke-Eke, heyjoeway">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
+		<import addon="game.controller.genesis.3button" version="1.0.0"/>
+		<import addon="game.controller.genesis.6button" version="1.0.0"/>
+		<import addon="game.controller.genesis.mouse" version="1.0.0"/>
+		<import addon="game.controller.genesis.4wayplay" version="1.0.0"/>
+		<import addon="game.controller.genesis.teamplayer" version="1.0.0"/>
+		<import addon="resource.games.libretro.restricted" version="1.0.0" optional="true"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.genplus-wide/resources/buttonmap.xml
+++ b/game.libretro.genplus-wide/resources/buttonmap.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-  <controller id="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="4">
+  <controller id="game.controller.genesis.3button" type="RETRO_DEVICE_JOYPAD" subclass="0">
+    <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+    <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+    <feature name="c" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+    <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+    <feature name="mode" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+    <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+    <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+    <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+  </controller>
+  <controller id="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="1">
     <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
     <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
     <feature name="c" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
@@ -21,4 +32,6 @@
     <feature name="start" mapto="RETRO_DEVICE_ID_MOUSE_MIDDLE"/>
     <feature name="pointer" mapto="RETRO_DEVICE_MOUSE"/>
   </controller>
+  <controller id="game.controller.genesis.4wayplay" type="RETRO_DEVICE_JOYPAD" subclass="3"/>
+  <controller id="game.controller.genesis.teamplayer" type="RETRO_DEVICE_JOYPAD" subclass="5"/>
 </buttonmap>

--- a/game.libretro.genplus-wide/resources/topology.xml
+++ b/game.libretro.genplus-wide/resources/topology.xml
@@ -1,35 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <logicaltopology>
-  <port type="controller" id="1">
+  <port type="controller" id="1" connectionPort="0">
+    <accepts controller="game.controller.genesis.3button"/>
     <accepts controller="game.controller.genesis.6button"/>
     <accepts controller="game.controller.genesis.mouse"/>
+    <accepts controller="game.controller.genesis.teamplayer">
+      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+    </accepts>
   </port>
-  <port type="controller" id="2">
+  <port type="controller" id="2" connectionPort="1">
+    <accepts controller="game.controller.genesis.3button"/>
     <accepts controller="game.controller.genesis.6button"/>
     <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="3">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="4">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="5">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="6">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="7">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
-  </port>
-  <port type="controller" id="8">
-    <accepts controller="game.controller.genesis.6button"/>
-    <accepts controller="game.controller.genesis.mouse"/>
+    <accepts controller="game.controller.genesis.4wayplay">
+      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+    </accepts>
+    <accepts controller="game.controller.genesis.teamplayer">
+      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
+        <accepts controller="game.controller.genesis.3button"/>
+        <accepts controller="game.controller.genesis.6button"/>
+      </port>
+    </accepts>
   </port>
 </logicaltopology>


### PR DESCRIPTION
Sorry for taking so long. If everything is ok, I'll prepare more PRs for other emulators.

This one is identical to the game.libretro.genplus (non-wide) (https://github.com/kodi-game/game.libretro.genplus/pull/13) except added dependencies that were missing in the addon.xml.

See also:

* https://github.com/kodi-game/game.libretro.genplus/issues/11
* https://github.com/kodi-game/game.libretro.genplus/pull/13